### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ have is:
 $Checkfront = new Checkfront(
     array(
         'host'=>'your-company.checkfront.com',
-        'consumer_key'  => '5010076404ec1809470508',
-        'consumer_secret' => 'ba0a5c0c509445024c374fcd264d41e816b02d4e',
+        'api_key'  => '5010076404ec1809470508',
+        'api_secret' => 'ba0a5c0c509445024c374fcd264d41e816b02d4e',
         'redirect_uri'=>'oob',
     )
 );

--- a/README.md
+++ b/README.md
@@ -35,14 +35,31 @@ Usage
 The examples are a good place to start. The minimal you'll need to
 have is:
 
+##### OAuth2 Access
+
 ```php
 <?
 $Checkfront = new Checkfront(
     array(
         'host'=>'your-company.checkfront.com',
+        'consumer_key'  => '5010076404ec1809470508',
+        'consumer_secret' => 'ba0a5c0c509445024c374fcd264d41e816b02d4e',
+        'redirect_uri'=>'oob',
+    )
+);
+?>
+```
+
+##### Token Access
+
+```php
+<?
+$Checkfront = new Checkfront(
+    array(
+        'host'=>'your-company.checkfront.com',
+	'auth_type' => 'token',
         'api_key'  => '5010076404ec1809470508',
         'api_secret' => 'ba0a5c0c509445024c374fcd264d41e816b02d4e',
-        'redirect_uri'=>'oob',
     )
 );
 ?>
@@ -52,9 +69,8 @@ $Checkfront = new Checkfront(
 <?
 /* Get items rates and availbility*/
 $Checkfront->get('item',array(
-							  'start_date'=>date('Y-m-d'),
-							  'end_date'=>date('Y-m-d',strtotime('+3 days'))
-							 )
-				);
+    'start_date'=>date('Y-m-d'),
+    'end_date'=>date('Y-m-d',strtotime('+3 days'))
+));
 ?>
 ```


### PR DESCRIPTION
Changed the examples in the README to use "api_*" instead of "consumer_*". Using consumer_ returns an error from Checkfront about a malformed auth header.