### PR TITLE
Cart Example: improve use of session storage; compatibility with session.use_strict_mode=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 1.4.0 (2019-04-04)
+
+### Examples
+ * Cart Example: No longer uses the booking session_id as the storage session's id
+ * Cart Example: Booking session data is now stored in `$_SESSION['booking_session']` instead of in the top level `$_SESSION`
+ * Cart Example: `Booking->query_inventory()` now accepts all query parameters [/api/3.0/item](http://api.checkfront.com/ref/item.html#get--api-3.0-item) uses

--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ is licensed under the Apache Licence, Version 2.0
 Updates
 -------
 
-* The 'Cart' example has been given a few quick fixes for v3 API support, using token pair auth.
-* The CheckfrontAPI library now supports connecting to the v3 API, as well as features like token pair authentication
-* New/updated examples are in the works.
-* See our v3 API documentation for more information.
+See [CHANGELOG.md](CHANGELOG.md)
 
 
 Features

--- a/examples/cart/Form.php
+++ b/examples/cart/Form.php
@@ -89,7 +89,7 @@ class Form {
 	}
 
 	private function build_checkbox($id,$data) {
-		$html = "<input type='checkbox' name='{$name}' id='{$id}' value='1'";
+		$html = "<input type='checkbox' name='{$id}' id='{$id}' value='1'";
 		if($data['value']) $html .= ' checked="checked"';
 		$html .= "/>";
 		return $html;

--- a/examples/cart/index.php
+++ b/examples/cart/index.php
@@ -47,7 +47,7 @@ $items = $Booking->query_inventory(
 	)
 );
 
-if(count($items)) {
+if (!empty($items)) {
 	$c = 0;
 	foreach($items as $item_id => $item) {
 		if (empty($item['rate']['slip'])) continue;
@@ -82,8 +82,8 @@ if(count($Booking->cart)) {
 	echo "<li><span style='font-family:monospace;font-size: .9em; color: #333'>Sub-total: {$_SESSION['sub_total']}<br/>";	
 	echo "Tax: {$_SESSION['tax_total']}<br/>";
 	echo "Total: {$_SESSION['total']}</span></li>";
-	echo '<li><input type="submit" name="create" value=" Book Now " /></li>';
-	echo '<li><input type="button" name="cancel" value=" Clear All " onClick="window.location=\'' . $_SERVER['SCRIPT_NAME'] . '?reset=1\';" /></li>';
+	echo '<li><button type="submit" name="create">Book Now</button></li>';
+	echo '<li><button type="button" name="cancel" onClick="window.location=\'' . $_SERVER['SCRIPT_NAME'] . '?reset=1\';">Clear All</button></li>';
 	
 } else {
 	echo '<p>EMPTY</p>';

--- a/lib/CheckfrontAPI.php
+++ b/lib/CheckfrontAPI.php
@@ -44,7 +44,7 @@
 */
 class CheckfrontAPI {
 
-	protected $sdk_version = '1.3';
+	protected $sdk_version = '1.4';
 	protected $api_version = '3.0';
 
 	public $error = array();


### PR DESCRIPTION
Checkfront is moving towards using `session.use_strict_mode=1`, which prevents clients from using arbitrary session_ids. The Cart example previously used the booking session_id for its own session storage, which wasn't a great example.

Cart example:
* No longer uses the booking session_id as the storage session's id
* Now reuses existing session if its present
* Booking session data is now stored in `$_SESSION['booking_session']` instead of in the top level `$_SESSION`, to avoid overwriting any non-booking session data
 * `Booking->query_inventory()` now accepts all query parameters [/api/3.0/item](http://api.checkfront.com/ref/item.html#get--api-3.0-item) uses, instead of just start_date/end_date (contrary to what the example usage then demonstrated)